### PR TITLE
Fix broken link on the Github page

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             </div>
             <div class="content row">
               <div class="span7 wrapped">
-                <h2>Download Latest <small>0.16.2</small></h2>
+                <h2>Download Latest <small>0.16.1</small></h2>
                 <table class="table">
                   <thead>
                     <tr>
@@ -120,14 +120,14 @@
                       <td>Full</td>
                       <td>
                         <ul>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback.js'>Development</a> <small>69 KB</small></li>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback.min.js'>Production</a> <small>32 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback.js'>Development</a> <small>69 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback.min.js'>Production</a> <small>32 KB</small></li>
                         </ul>
                       </td>
                       <td>
                         <ul>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback-full-stack.js'>Development</a> <small>330 KB</small></li>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback-full-stack.min.js'>Production</a> <small>102 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback-full-stack.js'>Development</a> <small>330 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback-full-stack.min.js'>Production</a> <small>102 KB</small></li>
                         </ul>
                       </td>
                     </tr>
@@ -135,14 +135,14 @@
                       <td>Core</td>
                       <td>
                         <ul>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback-core.js'>Development</a> <small>58 KB</small></li>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback-core.min.js'>Production</a> <small>27 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback-core.js'>Development</a> <small>58 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback-core.min.js'>Production</a> <small>27 KB</small></li>
                         </ul>
                       </td>
                       <td>
                         <ul>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback-core-stack.js'>Development</a> <small>319 KB</small></li>
-                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.2/knockback-core-stack.min.js'>Production</a> <small>98 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback-core-stack.js'>Development</a> <small>319 KB</small></li>
+                          <li><a href='https://raw.github.com/kmalakoff/knockback/0.16.1/knockback-core-stack.min.js'>Production</a> <small>98 KB</small></li>
                         </ul>
                       </td>
                     </tr>


### PR DESCRIPTION
Links to the lib files were all broken as they were targeting the 0.16.2 tag which doesn't exist.
You should either create this tag or target existing files as I did.
