### PR TITLE
bower.json: switch from SteveSanderson/knockout to bowerjs/knockout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "underscore": ">=1.1.7",
     "backbone": ">=0.5.1",
-    "knockout": ">=1.2.1"
+    "knockout": "knockout.js#>=1.2.1"
   },
 
   "license": "MIT"


### PR DESCRIPTION
SteveSanderson/knockout doesn't contain a compiled version of knockout, so it's impossible to use with bower if you're not also using grunt in your build workflow. bowerjs/knockout has been updated regularly, and should allow for a broader range of build setups.
