### PR TITLE
Release accessing read function of observable

### DIFF
--- a/src/knockback-core/knockback-core.coffee
+++ b/src/knockback-core/knockback-core.coffee
@@ -99,7 +99,7 @@ class kb
 
     # observable or lifecycle managed
     if ko.isObservable(obj) or (typeof(obj.dispose) is 'function') or (typeof(obj.destroy) is 'function') or (typeof(obj.release) is 'function')
-      if ko.isObservable(obj) and _.isArray(array = obj())
+      if ko.isObservable(obj) and _.isArray(array = obj.peek())
         if obj.__kb_is_co or (obj.__kb_is_o and (obj.valueType() is KB_TYPE_COLLECTION))
           if obj.destroy
             obj.destroy()


### PR DESCRIPTION
Tracked down a memory leak in my application that appears to originate
from the line. I was not able to reproduce this with core knockback and
it's dependencies. I was also not able to run the test suite on windows.
This is also my first commit to github. Given all that I won't be
offended by a rejection ;)

Thinking through it, there doesn't appear to be any reason why the
release function shouldn't be using peek here, but I can't prove that it
causes a problem outside of my application.

If you'd like more information about the approach we took with the app
I'd be happy to explain and share some code samples.

Also just wanted to say thanks, using knockback has helped greatly
reduce the amount of custom javascript code that I've seen backbone only
projects produce.
