### PR TITLE
IE lt 9 compatibility

### DIFF
--- a/src/core/index.coffee
+++ b/src/core/index.coffee
@@ -14,4 +14,4 @@ kb.configure = require './configure'
 # re-expose modules
 kb.modules = {underscore: kb._, backbone: kb.Parse or kb.Backbone, knockout: kb.ko}
 if window?
-  window[key] = kb[key] for key in ['_', 'Backbone', 'Parse', 'ko', '$'] when kb[key] and not window.hasOwnProperty(key)
+  window[key] = kb[key] for key in ['_', 'Backbone', 'Parse', 'ko', '$'] when kb[key] and not Object.prototype.hasOwnProperty.call(window, key)


### PR DESCRIPTION
'hasOwnProperty' method is not supported on host objects in Internet Explorer 8 and below.

It's a bit ugly, but a small compromise for browser support.
