### PR TITLE
Test case for issue #161

### DIFF
--- a/test/issues/issue161/issue-0.19.0.html
+++ b/test/issues/issue161/issue-0.19.0.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Knockback Issue 161 Test</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body>
+
+  <div id="some-div">
+    <h1>Parent</h1>
+    <span data-bind="html: name"></span>
+
+    <h2>Children</h2>
+    <ul data-bind="foreach: children">
+      <li><span data-bind="html: name"></span></li>
+    </ul>
+  </div>
+
+  <script type="text/javascript" src="https://unpkg.com/knockback@0.19.0/knockback-full-stack.js"></script>
+  <script src="issue-0.19.0.js"></script>
+
+</body>
+</html>

--- a/test/issues/issue161/issue-0.19.0.js
+++ b/test/issues/issue161/issue-0.19.0.js
@@ -1,0 +1,28 @@
+var children = new Backbone.Collection([
+  new Backbone.Model({name:"Charles"}),
+  new Backbone.Model({name:"Eve"})
+]);
+
+var parent = new Backbone.Model({
+  name:"Bob", children:children
+});
+
+var subFactory = function (model) {
+  var subVm = new kb.ViewModel(model);
+  subVm.cid = kb.ko.computed(function () {
+    return model.cid;
+  });
+  return subVm;
+};
+
+var vm = new kb.ViewModel(null, {excludes : ["children"]});
+
+vm.shareOptions().factory.addPathMapping("children.models", subFactory);
+vm.createObservables(null, ["children"]);
+
+vm.model(parent);
+
+ko.applyBindings(vm, document.getElementById("some-div"));
+
+console.log(vm.name());
+console.log(vm.children()[0].cid());

--- a/test/issues/issue161/issue.html
+++ b/test/issues/issue161/issue.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--[if lt IE 7]> <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Knockback Issue 161 Test</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body>
+
+  <div id="some-div">
+    <h1>Parent</h1>
+    <span data-bind="html: name"></span>
+
+    <h2>Children</h2>
+    <ul data-bind="foreach: children">
+      <li><span data-bind="html: name"></span></li>
+    </ul>
+  </div>
+
+  <script type="text/javascript" src="../../../node_modules/jquery/dist/jquery.js"></script>
+  <script type="text/javascript" src="../../../node_modules/knockout/build/output/knockout-latest.debug.js"></script>
+  <script type="text/javascript" src="../../../node_modules/underscore/underscore.js"></script>
+  <script type="text/javascript" src="../../../node_modules/backbone/backbone.js"></script>
+
+  <!-- LIBRARY -->
+  <script type="text/javascript" src="../../../knockback.js"></script>
+  <script src="issue.js"></script>
+
+</body>
+</html>

--- a/test/issues/issue161/issue.js
+++ b/test/issues/issue161/issue.js
@@ -1,0 +1,32 @@
+var children = new Backbone.Collection([
+  new Backbone.Model({name:"Charles"}),
+  new Backbone.Model({name:"Eve"})
+]);
+
+var parent = new Backbone.Model({
+  name:"Bob", children:children
+});
+
+var subFactory = function (model) {
+  var subVm = new kb.ViewModel(model);
+  subVm.cid = kb.ko.computed(function () {
+    return model.cid;
+  });
+  return subVm;
+};
+
+var vm = new kb.ViewModel(null, {
+  excludes : ["children"],
+  factories: {"children.models": subFactory}
+});
+
+// Passing in parent instead of null works but in my case I don't have parent
+// here so I must be able to set it later using vm.model(parent).
+vm.children = kb.observable(null, "children", vm.shareOptions());
+
+vm.model(parent);
+
+ko.applyBindings(vm, document.getElementById("some-div"));
+
+console.log(vm.name());
+console.log(vm.children()[0].cid());


### PR DESCRIPTION
This is a test case to replicate the problem described in issue #161.

In `issue.html` you'll can see the problem, the children doesn't show up.
In `issue-0.19.0.html` you see the same example working in 0.19.0.

Please note that by passing the parent into the `kb.observable` call I can make it work but in the real application the view model is build up in a much more complicated way so I must be able to set the model through `vm.model(parent)` later.